### PR TITLE
Fix addition with negative int64_t

### DIFF
--- a/src/Bint/arithmetics.cpp
+++ b/src/Bint/arithmetics.cpp
@@ -81,16 +81,13 @@ Bint& Bint::operator += (const int64_t a) {
 	bool carry = false;
 	addUintWithCarry(number[0], a, carry);
 
-	if (carry) {
-		if (negA) {
-			for(int j = 1; j < (int)number.size(); j++) {
-				addUintWithCarry(number[j], -1, carry);
-			}
-		} else {
-			for(int j = 1; j < (int)number.size(); j++) {
-				addUintWithCarry(number[j], 0, carry);
-				if (!carry) break;
-			}
+	if (negA) {
+		for(int j = 1; j < (int)number.size(); j++) {
+			addUintWithCarry(number[j], -1, carry);
+		}
+	} else {
+		for(int j = 1; carry && j < (int)number.size(); j++) {
+			addUintWithCarry(number[j], 0, carry);
 		}
 	}
 


### PR DESCRIPTION
Negative part wasn't always handled, so expressions like `(1 << 256) - 1` behaved incorrectly.

The result of the subtraction contained 5 64-bit numbers, but only first one was correct, i.e. had 0xffff... value. Next 3 parts were all 0's, and the last one was 1.

The fix is simple - just add the negative part of the operand if it was negative initially.

Initial behavior was kinda like unsigned addition, but `if (negA)` check ruined everything anyways because of incorrect addition of negative part. There's possibly an additional overload needed to have correct unsigned behavior.